### PR TITLE
Remove '-wp' from jQuery version string for WP v5.2 compatability

### DIFF
--- a/wp-jquery-plus.php
+++ b/wp-jquery-plus.php
@@ -23,8 +23,8 @@ function wpjp_set_src() {
 		wp_enqueue_script('jquery');
 
 		// Get current version of jQuery from WordPress core
-		$wp_jquery_ver = $GLOBALS['wp_scripts']->registered['jquery-core']->ver;
-		$wp_jquery_migrate_ver = $GLOBALS['wp_scripts']->registered['jquery-migrate']->ver;
+		$wp_jquery_ver = str_ireplace( '-wp', '', $GLOBALS['wp_scripts']->registered['jquery-core']->ver );
+		$wp_jquery_migrate_ver = str_ireplace( '-wp', '', $GLOBALS['wp_scripts']->registered['jquery-migrate']->ver );
 
 		// Set jQuery Google URL
 		if ( defined('WPJP_USE_CDNJS') )


### PR DESCRIPTION
Added `str_ireplace()` to remove the "-wp" string from the global jQuery versioning introduced in WordPress v5.2.1 which breaks the CDN URLs. 

_Tested WordPress v5.2.1_